### PR TITLE
MINOR: Tweak headings in 3D tutorail for compat with docs.

### DIFF
--- a/notebooks/tracking-3d.ipynb
+++ b/notebooks/tracking-3d.ipynb
@@ -9,11 +9,10 @@
   {
    "cells": [
     {
-     "cell_type": "heading",
-     "level": 1,
+     "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Feature finding in 3D confocal images"
+      "# Feature finding in 3D confocal images"
      ]
     },
     {
@@ -33,11 +32,10 @@
      ]
     },
     {
-     "cell_type": "heading",
-     "level": 2,
+     "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Setup IPython, pims, trackpy"
+      "## Setup IPython, pims, trackpy"
      ]
     },
     {
@@ -63,11 +61,10 @@
      "prompt_number": 1
     },
     {
-     "cell_type": "heading",
-     "level": 2,
+     "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Import 3D images"
+      "## Import 3D images"
      ]
     },
     {
@@ -213,11 +210,10 @@
      "prompt_number": 3
     },
     {
-     "cell_type": "heading",
-     "level": 1,
+     "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Feature finding"
+      "## Feature finding"
      ]
     },
     {
@@ -528,11 +524,10 @@
      "prompt_number": 8
     },
     {
-     "cell_type": "heading",
-     "level": 2,
+     "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Batch processing"
+      "## Batch processing"
      ]
     },
     {
@@ -562,11 +557,10 @@
      "prompt_number": 9
     },
     {
-     "cell_type": "heading",
-     "level": 1,
+     "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Linking"
+      "## Linking"
      ]
     },
     {
@@ -639,11 +633,10 @@
      "prompt_number": 11
     },
     {
-     "cell_type": "heading",
-     "level": 1,
+     "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Mean squared displacement"
+      "## Mean squared displacement"
      ]
     },
     {
@@ -711,11 +704,10 @@
      "prompt_number": 13
     },
     {
-     "cell_type": "heading",
-     "level": 1,
+     "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "About this work"
+      "## About this work"
      ]
     },
     {


### PR DESCRIPTION
@caspervdw I manually edited the notebook file to change your "heading" cells to "markdown" cells with h2-style headings. The pages doc/index.rst and doc/tutorials.rst automatically generate links from h1 headings.