### PR TITLE
Remove broken link to locate() API reference.

### DIFF
--- a/notebooks/walkthrough.ipynb
+++ b/notebooks/walkthrough.ipynb
@@ -3642,7 +3642,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are more options for controling and optimizing feature-finding. You can review them in the [documentation](https://trackpy.readthedocs.org/en/latest/reference/trackpy.feature.html). Or, pull them up as you work by typing ``tp.locate?`` into IPython."
+    "There are more options for controling and optimizing feature-finding. You can review them in the API Reference in the documentation. Or, pull them up as you work by typing ``tp.locate?`` into IPython."
    ]
   },
   {


### PR DESCRIPTION
See https://github.com/soft-matter/trackpy/issues/303 . Rather than update this, I've removed it in anticipation of a new URL scheme for the documentation, once we start archiving old versions.