### PR TITLE
Update old readthedocs link.

### DIFF
--- a/notebooks/walkthrough.ipynb
+++ b/notebooks/walkthrough.ipynb
@@ -3642,7 +3642,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are more options for controling and optimizing feature-finding. You can review them in the [documentation](https://trackpy.readthedocs.org/en/latest/reference/trackpy.feature.html). Or, pull them up as you work by typing ``tp.locate?`` into IPython."
+    "There are more options for controling and optimizing feature-finding. You can review them in the [documentation](https://soft-matter.github.io/trackpy/stable/generated/trackpy.feature.html). Or, pull them up as you work by typing ``tp.locate?`` into IPython."
    ]
   },
   {


### PR DESCRIPTION
Closes https://github.com/soft-matter/trackpy/issues/303. I made the link to .../trackpy/stable/... which technically does not work but *will* work once 0.3.0 is released. And it will continue to work, of course, as new versions are released.